### PR TITLE
Renamed Project to "resting"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.danichef</groupId>
-    <artifactId>Rest</artifactId>
+    <artifactId>resting</artifactId>
     <packaging>jar</packaging>
     <version>1.0-SNAPSHOT</version>
 

--- a/src/main/java/com/danichef/rest/Resting.java
+++ b/src/main/java/com/danichef/rest/Resting.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class Rest extends JavaPlugin {
+public class Resting extends JavaPlugin {
 
     @Getter
     private PlayerSit playerSit;

--- a/src/main/java/com/danichef/rest/player/seats/PlayerSitImpl.java
+++ b/src/main/java/com/danichef/rest/player/seats/PlayerSitImpl.java
@@ -1,7 +1,5 @@
 package com.danichef.rest.player.seats;
 
-import com.danichef.rest.Rest;
-import com.danichef.rest.utils.MessagesUtil;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.ArmorStand;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: '${name}'
-main: com.danichef.rest.Rest
+main: com.danichef.rest.Resting
 version: ${version}
 author: ${author}
 api-version: "1.15"


### PR DESCRIPTION
Before this commit was named "rest". This could cause much confusion as "rest" is widely known as an architectural style for providing standards between computer systems on the web.

As of this commit the project will be called "resting" to avoid confusion.